### PR TITLE
Fix initial sync

### DIFF
--- a/util.js
+++ b/util.js
@@ -10,6 +10,9 @@ function isIncludedInUp(migration, destination) {
 }
 
 function isIncludedInDown(migration, destination) {
+  if (!migration) {
+    return false;
+  }
   if(!destination) {
     return true;
   }


### PR DESCRIPTION
Syncing a DB that hadn't run any migrations yet would crash, because util.syncMode passes `completedMigrations[0]`, which would be undefined. I added a check in `isIncludedInDown`; if the passed migration is undefined, `isUncludedInDown` now returns false.