### PR TITLE
Add `json` and `jsonb` types

### DIFF
--- a/data_type.js
+++ b/data_type.js
@@ -12,6 +12,8 @@ module.exports = {
   DATE_TIME: 'datetime',
   TIME: 'time',
   BLOB: 'blob',
+  JSON: 'json',
+  JSONB: 'jsonb',
   TIMESTAMP: 'timestamp',
   BINARY: 'binary',
   BOOLEAN: 'boolean',


### PR DESCRIPTION
# This pull request is a proposal

It's helpful that users can select `json` and `jsonb` types.