### PR TITLE
feature: Added json datatype to mysql and shared

### DIFF
--- a/data_type.js
+++ b/data_type.js
@@ -15,5 +15,6 @@ module.exports = {
   TIMESTAMP: 'timestamp',
   BINARY: 'binary',
   BOOLEAN: 'boolean',
-  DECIMAL: 'decimal'
+  DECIMAL: 'decimal',
+  JSON: 'json'
 };


### PR DESCRIPTION
Both mysql and shared repos are missing the JSON data_type for MySQL.

Signed-off-by: Nicolás Rodrigues <git@nicorodrigues.com.ar>