### PR TITLE
Fix referencing isSilent under strict mode

### DIFF
--- a/log.js
+++ b/log.js
@@ -1,4 +1,4 @@
-this.isSilent = false;
+exports.isSilent = false;
 
 var logLevel = 15,
     escape = '"',
@@ -41,25 +41,25 @@ exports.setEscape = function( escapeChar ) {
   }
 };
 
-exports.silence = function (isSilent) {
-  return ( this.isSilent = isSilent );
+exports.silence = function (newIsSilent) {
+  return ( exports.isSilent = isSilent );
 };
 exports.info = function () {
-  if ((!this.isSilent || global.verbose) &&
+  if ((!exports.isSilent || global.verbose) &&
         logLevel & level.info) {
     Array.prototype.unshift.call(arguments, '[INFO]');
     console.info.apply(console, arguments);
   }
 };
 exports.warn = function () {
-  if ((!this.isSilent || global.verbose) &&
+  if ((!exports.isSilent || global.verbose) &&
        logLevel & level.warn) {
     Array.prototype.unshift.call(arguments, '[WARN]');
     console.warn.apply(console, arguments);
   }
 };
 exports.error = function () {
-  if ((!this.isSilent || global.verbose) &&
+  if ((!exports.isSilent || global.verbose) &&
         logLevel & level.error) {
     Array.prototype.unshift.call(arguments, '[ERROR]');
     //console.trace( 'Trace from error log' );
@@ -67,7 +67,7 @@ exports.error = function () {
   }
 };
 exports.sql = function(sql) {
-  if ((!this.isSilent && (global.dryRun || global.verbose))  &&
+  if ((!exports.isSilent && (global.dryRun || global.verbose))  &&
         logLevel & level.sql) {
     var args = Array.prototype.slice.call(arguments).slice(1);
     args = args.slice(0, args.length - 1);


### PR DESCRIPTION
Fixes https://github.com/db-migrate/node-db-migrate/issues/590

This PR fixes a bug where when running db-migrate under strict mode (such as via its [programmable api](https://db-migrate.readthedocs.io/en/latest/API/programable/) in a TS script), you'd get an undefined error when trying to reference `this.isSilent`. This is because under script mode, the `this` object is made undefined in a function as opposed to referencing the global scope (see "No this substitution" section in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#changes_in_strict_mode). Instead, we make the `isSilent` variable accessible on the `exports` object which gives the same overall characteristics as the global `this` (such as being accessible and changeable via require), but that `exports.isSilent` can be safely referenced within the functions.

An alternative approach could be:

```
this.isSilent = false;
var that = this;

// use that.isSilent everywhere
```

but this seemed more complicated than using `exports.isSilent`.
